### PR TITLE
[fix] inference resize 이슈 수정

### DIFF
--- a/pytorch/util/augmentation.py
+++ b/pytorch/util/augmentation.py
@@ -15,6 +15,6 @@ def get_valid_transform(args):
 
 def get_test_transform(args):
     return A.Compose([
-                    A.Resize(width=256, height=256),
+                    # A.Resize(width=args["RESIZE"][0], height=args["RESIZE"][1]),
                     ToTensorV2()
                     ])


### PR DESCRIPTION
- 기존 제공받았던 baseline 코드에서는 Inference 단계에서 원본 이미지 크기인 (512, 512) 크기로 predict mask 생성 후, 이를 제출 포맷에 맞게 (256, 256)으로 변경하는 방식
- 수정 전 코드에서는 Inference 단계에서 resize=(256, 256)이 적용되고 있으므로 수정 필요
